### PR TITLE
Allow loading of external XML entities in HHVM (files and HTTP resources)

### DIFF
--- a/etc/hhvm/php.ini
+++ b/etc/hhvm/php.ini
@@ -9,6 +9,7 @@ hhvm.log.level                           = Warning
 hhvm.log.always_log_unhandled_exceptions = true
 hhvm.log.runtime_error_reporting_level   = 8191
 hhvm.mysql.typed_results                 = false
+hhvm.libxml.ext_entity_whitelist         = file,http
 
 ; See: http://vanderveer.be/speed-up-composer-by-using-hhvm-including-a-slowtimer-error-fix/
 hhvm.resource_limit.socket_default_timeout = 30


### PR DESCRIPTION
Fixes [this kind of errors](https://github.com/facebook/hhvm/issues/3797)
